### PR TITLE
fixed leave function to allow going E and W

### DIFF
--- a/weatbag/tiles/n2.py
+++ b/weatbag/tiles/n2.py
@@ -13,13 +13,15 @@ class Tile:
             print("Someone has dropped a box of matches on the ground.")
     
     def leave(self, player, direction):
-        if direction=='s':
+        if direction=='n' and player.has('flaming torch'):
             return True
-        if player.has('flaming torch'):
-            return True
-        print("You can't explore the cave without being able to see. "
+        elif direction=='n' and not player.has('flaming torch'):
+            print("You can't explore the cave without being able to see. "
             "You'll need that stalwart friend of the adventurer, "
             "the flaming torch.")
+            return False
+        else:
+            return True
     
     def action(self, player, do):
         if (do[0] in words.take) and ('matches' in do):


### PR DESCRIPTION
I'm making a small quest nw and I noticed that in n2 the leave function wouldn't allow the player to go E nor W so I fixed that.
