### PR TITLE
Made the input more zork like

### DIFF
--- a/weatbag/__init__.py
+++ b/weatbag/__init__.py
@@ -112,7 +112,7 @@ def interact(player):
     while True:
         do = action.get_action()
         if action.is_move(do):
-            direction = do[1][0].lower()
+            direction = do[0][0].lower()
             # check if we can leave tile
             if not getattr(tile, 'leave', lambda p,d: True)(player, direction):
                 continue

--- a/weatbag/action.py
+++ b/weatbag/action.py
@@ -1,6 +1,7 @@
 import sys
 from . import words
 from weatbag.items import combine
+import random
 
 def get_action():
     """Prompts for an action, splits it into words, and removes any prepositions.
@@ -10,24 +11,28 @@ def get_action():
     """
     action = []
     while len(action) == 0:
-        action = input('> ').lower().split()
+        action = input('\n> ').lower().split()
         action = [w for w in action if w not in words.prepositions]
     return action
 
 move_directions = {'n','e','s','w','north','east','south','west'}
-
+mother=["You ought to be ashamed!","Such language for such a bold adventurer!","What would your mother say?"]
 def is_move(do):
-    return len(do) == 2 and (do[0] in words.move) and (do[1] in move_directions)      
+    return len(do) == 1 and (do[0] in words.move)
 
 def handle_action(tile, player, do):
     if len(do) == 1 and do[0] == 'quit':
+        print("until next time, adventurer!")
         sys.exit()
-        
-    elif len(do) == 2 and (do[0] in words.look) and (do[1] in words.surroundings):
+    if len(do) == 1 and (do[0]in words.help):
+        print("To move, use 'n,e,w,s'\nTo examine your surroundings, type:'look around'\nTo check your inventory, type:'bag' or 'i'\nOther commands will be intuitive to the situation.")        
+    if len(do) == 1 and (do[0]in words.swear):
+        print(random.choice(mother))
+    elif len(do) == 1 and (do[0] in words.look):
         # Look around
         tile.describe()
     
-    elif len(do) == 2 and (do[0] in words.look) and (do[1] in words.inventory):
+    elif len(do) == 1 and (do[0] in words.inventory):
         # Look at bag
         for item, n in player.inventory.most_common():
             if n < 1:

--- a/weatbag/tiles/e3.py
+++ b/weatbag/tiles/e3.py
@@ -1,0 +1,45 @@
+from weatbag import words
+import random
+
+class Tile:
+    def __init__(self):
+        self.contents = {'bag of gold': 1}
+        self.blocked='w'
+
+    
+    def describe(self):
+        if self.contents['bag of gold']:
+            print("you've been teleported to a magical room. Mysterious patterns ebb and swirl on the walls.\nA bag of gold sits on the floor.\n There is a wormhole to the west.")
+        else:
+            print("you've been teleported to a magical room. Mysterious patterns ebb and swirl on the walls.\n There is a wormhole to the west.")
+            
+    def action(self, player, do):
+        if do[0] == "explode" and not self.contents['bag of gold']: 
+            try: 
+                if do[1] == "self": 
+                    print("You start feeling queasy and your stomach rumbles.")
+                    print("All of the sudden, your entrails blow out of your body like "
+                        "Old Faithful."
+                        "The stench is horrible, and for a few seconds you marvel at"
+                        "how much pressure must have been built up inside of you."
+                        "I guess you should have laid off the beans last night at dinner?")
+                    player.hit_points=0
+                    player.give('biohazard waste')
+                    return
+            except: 
+                print("barnacles. You just dodged death while traversing the universe.")
+        if (do[0] in words.take) and ('gold' in do):
+            player.give('bag of gold')
+            self.contents['bag of gold'] -= 1
+        else:
+            print("Sorry, I don't understand.")
+            
+    def leave(self, player, direction):
+        if direction == "w":
+            if player.hit_points>0:
+                print("'"+player.name,", You must explode yourself first.'\nA mysterious voice rings out.")
+                return False
+            else:
+                print("The wormhole opens wide, and snatches and sucks you in like a starving sentient being.")
+                return True
+ 

--- a/weatbag/words.py
+++ b/weatbag/words.py
@@ -7,7 +7,7 @@ e.g. This will recognise take, pick, get or collect::
         #...
 """
 # Verbs
-move = {'move','walk','go'}
+move = {'n','w','s','e'}
 give = {'give', 'feed', 'present'}
 use = {'eat', 'use', 'wear'}
 fight = {'fight', 'kill', 'hit', 'attack'}
@@ -17,9 +17,10 @@ look = {'look', 'inspect', 'examine'}
 attack = {'attack', 'swing', 'hit', 'punch', 'fight'}
 combine = {'combine', 'join', 'mix'}
 talk = {'talk', 'speak', 'converse'}
-
+help = {'help', 'h'}
+swear = {'fuck','shit','ass','damn','cock','tits','goddammit','asshole'}
 # Nouns
-inventory = {'inventory', 'possessions', 'belongings', 'bag'}
+inventory = {'inventory', 'possessions', 'belongings', 'bag','i'}
 surroundings = {'surroundings', 'around', 'scenery'}
 
 prepositions = {'up', 'down', 'on', 'under', 'in', 'at', 'to', 'with', 'and'}


### PR DESCRIPTION
Meaning instead of having to type two words to move around, you can simply type 'n','e','w', or 's'.

Gave abbreviations to commands, and added a 'help' response for people who haven't played text games before.

Also added a swear dictionary for frustrated adventurers.

just typing 'look' for looking around, and 'bag' or 'i' for viewing the inventory seems more intuitive than using a series of commands. Also easier to quickly input. This is how it was done in zork, and while totally subjective,I think it's a bit nicer to use :+1: 
